### PR TITLE
Resolves #1

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -134,6 +134,9 @@ body {
   font-weight: 600;
   font-family: "Montserrat Subrayada", sans-serif;
   margin-bottom: 0;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  hyphens: auto;
 }
 
 @media (min-width: 576px) {


### PR DESCRIPTION
Deals with long city name overflow by wrapping. Throwing in hyphens style just in case. Tested in Microsoft Edge (version 85.0.564.44) and Opera (version 70.0.3728.154).